### PR TITLE
Updates to v0.0.28

### DIFF
--- a/studio.assetmanager.ams.yaml
+++ b/studio.assetmanager.ams.yaml
@@ -59,8 +59,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://assetmanager.studio/dl/0.0.27/asset-manager-studio_0.0.27_amd64.deb
-        sha256: a83fa30b4c3a36e3c541bc1931cb5ca3756864bf63b6c72f235d3a0796639fac
+        url: https://assetmanager.studio/dl/0.0.28/asset-manager-studio_0.0.28_amd64.deb
+        sha256: 80f2fcb6c5cced3016a83c2d87393e01f8ab4a2722b52c4560f00535cf8843fe
       - type: script
         dest-filename: ams.sh
         commands:


### PR DESCRIPTION
- 0.0.28 - 2025/05/01 - Auto-Cleanup of IOS / TVOS code if not on MacOS
                      - Added Developer sort to Asset screen
                      - Added "ALLOW_BARE_VAULT" as a new hidden setting (see wiki)
                      - Added "SKIP_SAVE_VAULT_JSON" as a new hidden setting (see wiki)
                      - Added Developer name to Vault screen
                      - Added "Third Party" type filter to vault screen.
                      - Fix Error creating directory
                      - Update to say Show on Fab / Marketplace depending on asset site for Context menu
                      - Update AssetCredits to show the correct source w/ FAB assets
                      - No longer auto-hide login window until we can duplicate the issue with Epic's required License acceptation ("AUTO_CLOSE_LOGIN" is the hidden setting you can use to change this)
                      - Update to Electron 33.4.9 (& other supports)
                      - Allow selection of asset version to download
                      - Added animations for detail windows
                      - Minor fixes with data and display
                      - Added new Engine Filters for Asset Screen
                      - Added Asset Count to Asset screen
                      - Added Export system
                      - Added Vault context ability to view source asset
                      - Fixed issue with CLI export of assets
                      - Install into Project drop down list now shows the path when you hover over the project name
                      - Will now use a choice dialog if it detects a place where we are overwriting a file during installation of an asset.
                      - Added missing dialogs for Create/Install into project/engine
                      - Added new settings to have different size icons
