### PR TITLE
v1.0.2 - Revert back to X11, and force AMS to be x11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Installing from the flathub.org repository
 See https://flathub.org/apps/details/studio.assetmanager.ams for details.
 
+# Update the manifest file (BEFORE building .deb)
+../launcher/buildResources/studio.assetmanager.ams.metainfo.xml
+
 # verify the manifest file
 - flatpak run org.freedesktop.appstream.cli validate ../launcher/buildResources/studio.assetmanager.ams.metainfo.xml
 
@@ -15,6 +18,7 @@ See https://flathub.org/apps/details/studio.assetmanager.ams for details.
   
 - To update the flathub version:
   - update the "studio.assetmanager.ams.metainfo.yaml" file
-  - create a new branch and create a pull request.
+  - CREATE A NEW BRANCH!!!
+  - commit and create a pull request.
   - verify the pull request output
   - merge the pull request

--- a/studio.assetmanager.ams.yaml
+++ b/studio.assetmanager.ams.yaml
@@ -64,7 +64,7 @@ modules:
         only-arches:
           - x86_64
         url: https://assetmanager.studio/dl/1.0.2/asset-manager-studio_1.0.2_amd64.deb
-        sha256: 566afc300cb71916c164fc286065204fa4bb3f4ac3b55cb13361259aadd47d11
+        sha256: 8b8f355b21531d9796e32049b3157da68613a4c8a285d17c229598735f7e0a78
       - type: script
         dest-filename: ams.sh
         commands:

--- a/studio.assetmanager.ams.yaml
+++ b/studio.assetmanager.ams.yaml
@@ -8,9 +8,11 @@ command: ams
 finish-args:
   # X11 performance
   - --share=ipc
+  # We Require x11 support, because UNREAL fails/crashes currently under Wayland, using wayland here, force Unreal to work as wayland
+  - --socket=x11
   # Wayland/x11 support
-  - --socket=wayland
-  - --socket=fallback-x11
+  # - --socket=wayland
+  # - --socket=fallback-x11
   # Access to network
   - --share=network
   # Audio Access
@@ -61,10 +63,10 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://assetmanager.studio/dl/1.0.1/asset-manager-studio_1.0.1_amd64.deb
-        sha256: 42fe6df969dfe475daee2d3561503f595caba59b06f660603f4e0e343c222ae3
+        url: https://assetmanager.studio/dl/1.0.2/asset-manager-studio_1.0.2_amd64.deb
+        sha256: 566afc300cb71916c164fc286065204fa4bb3f4ac3b55cb13361259aadd47d11
       - type: script
         dest-filename: ams.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/asset-manager-studio/asset-manager-studio "$@"
+          - exec zypak-wrapper /app/asset-manager-studio/asset-manager-studio --ozone-platform=x11 "$@"


### PR DESCRIPTION
Unreal engine has major issues still running under wayland, we need it to run under XWayland properly.   Do to the permissions system of Flatpak, we have to force AMS to be x11, to make any apps we shell out to be X11.